### PR TITLE
src: add Fluidd feed

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -22,5 +22,11 @@
         "repo_name": "moonraker-telegram-bot",
         "description": "Telegram bot to interact with Moonraker",
         "authorized_creators": ["aka13-404", "nlef"]
+    },
+    "fluidd": {
+        "repo_owner": "fluidd-core",
+        "repo_name": "fluidd",
+        "description": "Fluidd, the klipper UI.",
+        "authorized_creators": ["cadriel", "eduncan911", "matmen", "pecirep", "pedrolamas"]
     }
 }


### PR DESCRIPTION
Adds `fluidd-core/fluidd` as an announcement source, including everyone in the Admin and Maintainer org roles as authorized creators.