### PR TITLE
add announcements for RatOS

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -37,7 +37,7 @@
     },
     "RatOS": {
         "repo_owner": "Rat-OS",
-        "repo_name": "RatOS-configurator",
+        "repo_name": "RatOS",
         "description": "Configurator for Klipper and RatOS",
         "authorized_creators": ["miklschmidt"]
     }

--- a/src/config.json
+++ b/src/config.json
@@ -38,7 +38,7 @@
     "RatOS": {
         "repo_owner": "Rat-OS",
         "repo_name": "RatOS",
-        "description": "Configurator for Klipper and RatOS",
+        "description": "An OS focusing on making klipper more approachable",
         "authorized_creators": ["miklschmidt"]
     }
 }

--- a/src/config.json
+++ b/src/config.json
@@ -34,5 +34,11 @@
         "repo_name": "mobileraker",
         "description": "A iOS and Android mobile app for Klipper.",
         "authorized_creators": ["Clon1998"]
+    },
+    "RatOS": {
+        "repo_owner": "Rat-OS",
+        "repo_name": "RatOS-configurator",
+        "description": "Configurator for Klipper and RatOS",
+        "authorized_creators": ["miklschmidt"]
     }
 }


### PR DESCRIPTION
I wasn't sure whether the RatOS repo itself qualified, so i'm using the RatOS-configurator repository, because that does. In case it's OK to use Rat-OS/RatOS, i'd prefer that, and i'll change the request. Thanks! :)